### PR TITLE
Allow users to install borgbackup package instead of downloading binary

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ borgbackup_ssh_key: "~{{ borgbackup_client_user }}/.ssh/id_borg_rsa"
 
 borgbackup_binary: borg
 borgbackup_install_from_pkg: false
+borgbackup_install_epel: true
 borgbackup_package: borgbackup
 
 borgbackup_version: "1.1.4"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,10 @@ borgbackup_required: true
 borgbackup_client_user: root
 borgbackup_ssh_key: "~{{ borgbackup_client_user }}/.ssh/id_borg_rsa"
 
+borgbackup_binary: borg
+borgbackup_install_from_pkg: false
+borgbackup_package: borgbackup
+
 borgbackup_version: "1.1.4"
 borgbackup_checksum: "sha256:4ecf507f21f0db7c437b2ef34566273d7ba5a7d05e921c6f0e3406c3f96933a7"
 borgbackup_download_url: "https://github.com/borgbackup/borg/releases/download/{{ borgbackup_version }}/borg-linux64"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ borgbackup_ssh_key: "~{{ borgbackup_client_user }}/.ssh/id_borg_rsa"
 
 borgbackup_binary: borg
 borgbackup_install_from_pkg: false
-borgbackup_install_epel: true
+borgbackup_install_epel: false
 borgbackup_package: borgbackup
 
 borgbackup_version: "1.1.4"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,3 @@
+---
+- src: geerlingguy.repo-epel
+  version: 1.2.3

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,12 @@
 ---
-- name: install borg backup
+# Use full path when using borg binary downloaded from web
+- name: install | set borg binary path
+  set_fact:
+    borgbackup_binary: "/usr/local/bin/borg"
+  tags: borginstall
+  when: not borgbackup_install_from_pkg
+
+- name: install | install borg binary from web
   get_url:
     dest: "/usr/local/bin/borg"
     checksum: "{{ borgbackup_checksum }}"
@@ -8,3 +15,11 @@
     mode: "0755"
     url: "{{ borgbackup_download_url }}"
   tags: borginstall
+  when: not borgbackup_install_from_pkg
+
+- name: install | install borgbackup package
+  package:
+    name: "{{ borgbackup_package }}"
+    state: present
+  tags: borginstall
+  when: borgbackup_install_from_pkg

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- include_tasks: setup-RedHat.yml
+  when: borgbackup_install_from_pkg and ansible_os_family == 'RedHat'
+
 # Due to inverse logic behaviour when searching for an item in an undefined list.
 - name: setting facts
   set_fact:

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,0 +1,4 @@
+---
+- name: "Install EPEL repo"
+  include_role:
+    name: geerlingguy.repo-epel

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -2,3 +2,4 @@
 - name: "Install EPEL repo"
   include_role:
     name: geerlingguy.repo-epel
+  when: borgbackup_install_epel

--- a/templates/borg-backup.sh.j2
+++ b/templates/borg-backup.sh.j2
@@ -20,7 +20,7 @@ if [ "$1" = "info" ]
 {% else %}
     REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
 {% endif %}
-    /usr/local/bin/borg info {{ b.options }} $REPOSITORY::$2
+    {{ borgbackup_binary }} info {{ b.options }} $REPOSITORY::$2
 {% endfor %}
     exit 0
 fi
@@ -36,7 +36,7 @@ if [ "$1" = "mount" ]
 {% else %}
     REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
 {% endif %}
-    /usr/local/bin/borg mount {{ b.options }} $REPOSITORY::$3 $4
+    {{ borgbackup_binary }} mount {{ b.options }} $REPOSITORY::$3 $4
     if [ "$?" = "0" ]; then printf "Backup mounted on $4, do not forget to unmount!\n"; fi
     exit 0
 {% endfor %}
@@ -51,7 +51,7 @@ if [ "$1" = "list" ]
     REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
 {% endif %}
     printf "Archives on {{ b.fqdn }} :\n"
-    /usr/local/bin/borg list {{ b.options }} -v $REPOSITORY
+    {{ borgbackup_binary }} list {{ b.options }} -v $REPOSITORY
 {% endfor %}
     exit 0
 fi
@@ -64,7 +64,7 @@ if [ "$1" = "init" ]
 {% else %}
     REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
 {% endif %}
-    /usr/local/bin/borg init --encryption={{ borgbackup_encryption_mode }}{% if borgbackup_appendonly_repoconfig %} --append-only{% endif %} {{ b.options }} $REPOSITORY
+    {{ borgbackup_binary }} init --encryption={{ borgbackup_encryption_mode }}{% if borgbackup_appendonly_repoconfig %} --append-only{% endif %} {{ b.options }} $REPOSITORY
 {% endfor %}
     exit 0
 fi
@@ -86,13 +86,13 @@ if [ "$1" = "backup" ]
     REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ inventory_hostname }}
 {% endif %}
     
-    /usr/local/bin/borg create --progress --compression {{ borgbackup_compression }} --stats {{ b.options }} $REPOSITORY::$date {% for dir in borgbackup_include %}{{ dir }} {% endfor %}{% if automysql.stat.isdir is defined and automysql.stat.isdir == True %}/var/lib/automysqlbackup{% endif %} {% for dir in borgbackup_exclude %} --exclude '{{ dir }}'{% endfor %}
+    {{ borgbackup_binary }} create --progress --compression {{ borgbackup_compression }} --stats {{ b.options }} $REPOSITORY::$date {% for dir in borgbackup_include %}{{ dir }} {% endfor %}{% if automysql.stat.isdir is defined and automysql.stat.isdir == True %}/var/lib/automysqlbackup{% endif %} {% for dir in borgbackup_exclude %} --exclude '{{ dir }}'{% endfor %}
 
     if [ "$?" -eq "0" ]; then printf "Backup succeeded on $date to {{ b.fqdn }}\n" >> /var/log/borg-backup.log; fi
 
   {% if not borgbackup_appendonly %}
     # prune old backups
-    /usr/local/bin/borg prune {{ b.options }} -v $REPOSITORY -H {{ borgbackup_retention.hourly }} -d {{ borgbackup_retention.daily }} -w {{ borgbackup_retention.weekly }} -m {{ borgbackup_retention.monthly }} -y {{ borgbackup_retention.yearly }}
+    {{ borgbackup_binary }} prune {{ b.options }} -v $REPOSITORY -H {{ borgbackup_retention.hourly }} -d {{ borgbackup_retention.daily }} -w {{ borgbackup_retention.weekly }} -m {{ borgbackup_retention.monthly }} -y {{ borgbackup_retention.yearly }}
   {% endif %}
 {% endfor %}
 

--- a/templates/prune.sh.j2
+++ b/templates/prune.sh.j2
@@ -19,7 +19,7 @@
 {% else %}
       REPOSITORY={{ b.user }}@{{ b.fqdn }}:{{ b.home }}{{ b.pool }}/{{ h }}
 {% endif %}
-      /usr/local/bin/borg prune -v $REPOSITORY {{ b.options }} -H {{ hostvars[h].borgbackup_retention.hourly }} -d {{ hostvars[h].borgbackup_retention.daily }} -w {{ hostvars[h].borgbackup_retention.weekly }} -m {{ hostvars[h].borgbackup_retention.monthly }} -y {{ hostvars[h].borgbackup_retention.yearly }}
+      {{ borgbackup_binary }} prune -v $REPOSITORY {{ b.options }} -H {{ hostvars[h].borgbackup_retention.hourly }} -d {{ hostvars[h].borgbackup_retention.daily }} -w {{ hostvars[h].borgbackup_retention.weekly }} -m {{ hostvars[h].borgbackup_retention.monthly }} -y {{ hostvars[h].borgbackup_retention.yearly }}
 
   {% endfor %}
   {% endif %}


### PR DESCRIPTION
This adds support for installing borg backup from EPEL instead of downloading a binary from the web. I opened this PR to upstream, but it looks like a similar PR was opened (for Debian) a while back, so I'm not too optimistic.

If `fiaasco.borbackup` turns out to be unmaintained, we may want to consider putting this on Galaxy and maintaining our own fork.