### PR TITLE
Add no_log to avoid outputting borg passphrase

### DIFF
--- a/tasks/borg-client.yml
+++ b/tasks/borg-client.yml
@@ -18,6 +18,7 @@
     state: "present"
     line: 'export BORG_PASSPHRASE="{{ borgbackup_passphrase }}"'
     create: true
+  no_log: true
 
 - name: client | disable strict key checking for backup servers
   blockinfile:


### PR DESCRIPTION
Adding `no_log: true` prevents outputting the secret when running ansible with the `--diff` flag. This is a useful precaution in case users are doing something with the output without realizing it might contain a secret.